### PR TITLE
Add Pristina International Airport as `LYPR`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 airportsdata
 ============
 
-.. |ICAO| replace:: 28,875
+.. |ICAO| replace:: 28,876
 
 .. |IATA| replace:: 6,565
 

--- a/airportsdata/airports.csv
+++ b/airportsdata/airports.csv
@@ -16413,6 +16413,7 @@
 "LYNS","QND","Cenej Airport","Novi Sad","","RS",266,45.385799,19.839199,"Europe/Belgrade"
 "LYPG","TGD","Podgorica Airport","Podgorica","Podgorica","ME",141,42.3594017029,19.2518997192,"Europe/Podgorica"
 "LYPO","","Cemovsko Polje Airport","Podgorica","","ME",197,42.4223175049,19.2907772064,"Europe/Podgorica"
+"LYPR","PRN","Pristina International Airport","Prishtina","Pristina","XK",1789,42.5727996826,21.0358009338,"Europe/Belgrade"
 "LYPT","","Batlava-Donja Penduha Airfield","Batlava","Pristina","XK",1978,42.845500946,21.2199993134,"Europe/Belgrade"
 "LYSM","","Veliki Radinci Airfield","Sremska Mitrovica","","RS",320,45.037453,19.660661,"Europe/Belgrade"
 "LYSP","","Rudine airfield","Smederevska palanka","","RS",0,44.3513888889,20.96,"Europe/Belgrade"


### PR DESCRIPTION
It appears that Pristina International Airport has two ICAOs: `BKPR` and `LYPR`.
It is also not listed in [IATA database](https://www.iata.org/en/publications/directories/code-search/). What should we do about this?