### PR TITLE
Build source distribution for pypi

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -149,10 +149,9 @@ jobs:
           pip install -U pip setuptools wheel
           pip install -U .
 
-      # Only building wheel; otherwise run 'python setup.py sdist bdist_wheel'
       - name: Build dist
         run: |
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
 
       # PyPI publish GitHub Action from https://github.com/pypa/gh-action-pypi-publish
       - name: Publish package


### PR DESCRIPTION
Certain packaging options require the source distribution specifically
to be available on pypi and cannot use the binary distribution.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

---

Building with `fpm` fails because it requires a source distribution. Having this would mean I don't have reinvent the wheel and build a package from source: https://github.com/jordansissel/fpm/blob/788170598572ab2a9cb4d844575e3a9dab2ab467/lib/fpm/package/python.rb#L153