### PR TITLE
Fix city spelling for LCA/LCLK: "Larnarca" -> "Larnaca"

### DIFF
--- a/airportsdata/airports.csv
+++ b/airportsdata/airports.csv
@@ -14942,7 +14942,7 @@
 "LBWN","VAR","Varna Airport","Varna","Varna","BG",230,43.2321,27.8251,"Europe/Sofia",""
 "LBWV","","Izgrev Airport","Izgrev","Varna","BG",1119,43.27722,27.70194,"Europe/Sofia",""
 "LCEN","ECN","Ercan International Airport","Nicosia","Nicosia","CY",404,35.1547,33.4961,"Asia/Nicosia",""
-"LCLK","LCA","Larnaca International Airport","Larnarca","Larnaka","CY",8,34.8751,33.6249,"Asia/Nicosia",""
+"LCLK","LCA","Larnaca International Airport","Larnaca","Larnaka","CY",8,34.8751,33.6249,"Asia/Nicosia",""
 "LCPH","PFO","Paphos International Airport","Paphos","Pafos","CY",41,34.718,32.4857,"Asia/Nicosia",""
 "LCRA","AKT","RAF Akrotiri","","","CY",76,34.5904,32.9879,"Asia/Nicosia",""
 "LD57","","Sepurine Training Base","Zaton","Zadarska","HR",60,44.21,15.1632,"Europe/Zagreb",""


### PR DESCRIPTION
One-cell data fix: the `city` field for Larnaca International Airport (LCA/LCLK) is spelled "Larnarca"; the record's own `name` field already spells it correctly. Sources and detail in #95 (IATA code search, Hermes Airports, SkyVector).

Fixes #95.